### PR TITLE
[🐸 Frogbot] Update version of express-jwt to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "exif": "^0.6.0",
     "express": "^4.17.1",
     "express-ipfilter": "^1.2.0",
-    "express-jwt": "0.1.3",
+    "express-jwt": "^6.0.0",
     "express-rate-limit": "^5.3.0",
     "express-robots-txt": "^0.4.1",
     "express-security.txt": "^2.0.0",


### PR DESCRIPTION
<div align='center'>

[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)

</div>


## 📦 Vulnerable Dependencies
### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical | Undetermined | express-jwt:0.1.3 | express-jwt 0.1.3 | [6.0.0] | CVE-2020-15084 |

</div>

### 🔬 Research Details
**Description:**
In express-jwt (NPM package) up and including version 5.3.3, the algorithms entry to be specified in the configuration is not being enforced. When algorithms is not specified in the configuration, with the combination of jwks-rsa, it may lead to authorization bypass. You are affected by this vulnerability if all of the following conditions apply: - You are using express-jwt - You do not have **algorithms** configured in your express-jwt configuration. - You are using libraries such as jwks-rsa as the **secret**. You can fix this by specifying **algorithms** in the express-jwt configuration. See linked GHSA for example. This is also fixed in version 6.0.0.


---
<div align='center'>

[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)

</div>
